### PR TITLE
fix: node manager eip 165 

### DIFF
--- a/contracts/oracle/modules/NodeManager.sol
+++ b/contracts/oracle/modules/NodeManager.sol
@@ -49,7 +49,7 @@ contract NodeManager is INodeManager {
     /// @param interfaceId The ID of the interface to check.
     /// @return A boolean indicating whether the contract supports the interface.
     function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
-        return interfaceId == type(INodeManager).interfaceId;
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(INodeManager).interfaceId;
     }
 
     /// @notice Gets the ID of a node from its node definition: node type, parameters, parents.

--- a/contracts/oracle/test/MockNodeManager.sol
+++ b/contracts/oracle/test/MockNodeManager.sol
@@ -43,6 +43,14 @@ contract MockNodeManager is INodeManager {
         return _supportsInterface;
     }
 
+    function getINodeManagerInterface() external pure returns (bytes4) {
+        return type(INodeManager).interfaceId;
+    }
+
+    function getERC165Selector() external pure returns (bytes4) {
+        return type(IERC165).interfaceId;
+    }
+
     function getNodeId(
         NodeDefinition.NodeType,
         bytes calldata,


### PR DESCRIPTION
### Describe the bug
NodeManager::supportsInterface doesn't follow EIP-165 as it incorrectly returns false for the EIP-165 interface ID `0x01ffc9a7`

### Impact Details
Integrators of `NodeManager` may fail if it checks whether it supports interface

### Relevant Code
https://github.com/Folks-Finance/folks-finance-xchain-contracts/blob/b6a0043d649075f4548dec34280027c8b0296d53/contracts/oracle/modules/NodeManager.sol#L51-L53

### Proposed Fix
Update function implementation to be `return interfaceId == type(IERC165).interfaceId || interfaceId == type(INodeManager).interfaceId`

