### PR TITLE
fix: use cctp source domain id in message keys

### DIFF
--- a/contracts/bridge/WormholeCCTPAdapter.sol
+++ b/contracts/bridge/WormholeCCTPAdapter.sol
@@ -261,7 +261,7 @@ contract WormholeCCTPAdapter is IBridgeAdapter, IWormholeReceiver, AccessControl
 
         // return info so can pair Circle Token transfer with Wormhole message
         MessageKey[] memory messageKeys = new MessageKey[](1);
-        messageKeys[0] = MessageKey(CCTPMessageLib.CCTP_KEY_TYPE, abi.encodePacked(destinationDomain, nonce));
+        messageKeys[0] = MessageKey(CCTPMessageLib.CCTP_KEY_TYPE, abi.encodePacked(cctpSourceDomainId, nonce));
         return (messageKeys, nonce);
     }
 

--- a/test/bridge/WormholeCCTPAdapter.test.ts
+++ b/test/bridge/WormholeCCTPAdapter.test.ts
@@ -391,7 +391,7 @@ describe("WormholeCCTPAdapter (unit tests)", () => {
             [
               convertNumberToBytes(2, UINT8_LENGTH),
               ethers.concat([
-                convertNumberToBytes(cctpDomainId, UINT32_LENGTH),
+                convertNumberToBytes(cctpSourceDomainId, UINT32_LENGTH),
                 convertNumberToBytes(nonce, UINT64_LENGTH),
               ]),
             ],


### PR DESCRIPTION
fix: #10 