### PR TITLE
WormholeExecutorDataAdapter

### DIFF
--- a/contracts/bridge/WormholeCCTPAdapter.sol
+++ b/contracts/bridge/WormholeCCTPAdapter.sol
@@ -2,13 +2,12 @@
 pragma solidity 0.8.23;
 
 import "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
-import "@wormhole-solidity-sdk/interfaces/IERC20.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormhole.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormholeReceiver.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormholeRelayer.sol";
-import "@wormhole-solidity-sdk/interfaces/CCTPInterfaces/ITokenMessenger.sol";
-import "@wormhole-solidity-sdk/interfaces/CCTPInterfaces/IMessageTransmitter.sol";
-import { CCTPMessageLib } from "@wormhole-solidity-sdk/CCTPBase.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "wormhole-sdk/interfaces/ICoreBridge.sol";
+import "wormhole-sdk/interfaces/IWormholeRelayer.sol";
+import "wormhole-sdk/interfaces/cctp/ITokenMessenger.sol";
+import "wormhole-sdk/interfaces/cctp/IMessageTransmitter.sol";
+import "wormhole-sdk/WormholeRelayer/Keys.sol";
 
 import "./interfaces/IBridgeAdapter.sol";
 import "./interfaces/IBridgeRouter.sol";
@@ -38,7 +37,7 @@ contract WormholeCCTPAdapter is IBridgeAdapter, IWormholeReceiver, AccessControl
     mapping(uint16 folksChainId => WormholeCCTPAdapterParams) internal folksChainIdToWormholeAdapter;
     mapping(uint16 wormholeChainId => uint16 folksChainId) internal wormholeChainIdToFolksChainId;
 
-    IWormhole public immutable wormhole;
+    ICoreBridge public immutable wormhole;
     IWormholeRelayer public immutable wormholeRelayer;
     IBridgeRouter public immutable bridgeRouter;
     ITokenMessenger public immutable circleTokenMessenger;
@@ -71,7 +70,7 @@ contract WormholeCCTPAdapter is IBridgeAdapter, IWormholeReceiver, AccessControl
      */
     constructor(
         address admin,
-        IWormhole _wormhole,
+        ICoreBridge _wormhole,
         IWormholeRelayer _wormholeRelayer,
         IBridgeRouter _bridgeRouter,
         IMessageTransmitter _circleMessageTransmitter,
@@ -270,7 +269,7 @@ contract WormholeCCTPAdapter is IBridgeAdapter, IWormholeReceiver, AccessControl
 
         // return info so can pair Circle Token transfer with Wormhole message
         MessageKey[] memory messageKeys = new MessageKey[](1);
-        messageKeys[0] = MessageKey(CCTPMessageLib.CCTP_KEY_TYPE, abi.encodePacked(cctpSourceDomainId, nonce));
+        messageKeys[0] = MessageKey(WormholeRelayerKeysLib.KEY_TYPE_CCTP, abi.encodePacked(cctpSourceDomainId, nonce));
         return (messageKeys, nonce);
     }
 

--- a/contracts/bridge/WormholeDataAdapter.sol
+++ b/contracts/bridge/WormholeDataAdapter.sol
@@ -2,9 +2,8 @@
 pragma solidity 0.8.23;
 
 import "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormhole.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormholeReceiver.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormholeRelayer.sol";
+import "wormhole-sdk/interfaces/ICoreBridge.sol";
+import "wormhole-sdk/interfaces/IWormholeRelayer.sol";
 
 import "./interfaces/IBridgeAdapter.sol";
 import "./interfaces/IBridgeRouter.sol";
@@ -27,7 +26,7 @@ contract WormholeDataAdapter is IBridgeAdapter, IWormholeReceiver, AccessControl
     mapping(uint16 folksChainId => WormholeAdapterParams) internal folksChainIdToWormholeAdapter;
     mapping(uint16 wormholeChainId => uint16 folksChainId) internal wormholeChainIdToFolksChainId;
 
-    IWormhole public immutable wormhole;
+    ICoreBridge public immutable wormhole;
     IWormholeRelayer public immutable wormholeRelayer;
     IBridgeRouter public immutable bridgeRouter;
     address public refundAddress;
@@ -52,7 +51,7 @@ contract WormholeDataAdapter is IBridgeAdapter, IWormholeReceiver, AccessControl
      */
     constructor(
         address admin,
-        IWormhole _wormhole,
+        ICoreBridge _wormhole,
         IWormholeRelayer _wormholeRelayer,
         IBridgeRouter _bridgeRouter,
         address _refundAddress

--- a/contracts/bridge/WormholeExecutorDataAdapter.sol
+++ b/contracts/bridge/WormholeExecutorDataAdapter.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
+import { ICoreBridge } from "wormhole-sdk/interfaces/ICoreBridge.sol";
+import { IExecutorQuoterRouter, IVaaV1Receiver } from "wormhole-sdk/interfaces/IExecutor.sol";
+import { CoreBridgeLib } from "wormhole-sdk/libraries/CoreBridge.sol";
+import { HashReplayProtectionLib } from "wormhole-sdk/libraries/ReplayProtection.sol";
+import { VaaLib } from "wormhole-sdk/libraries/VaaLib.sol";
+import { RequestLib } from "wormhole-sdk/Executor/Request.sol";
+import { RelayInstructionLib } from "wormhole-sdk/Executor/RelayInstruction.sol";
+
+import "./interfaces/IBridgeAdapter.sol";
+import "./interfaces/IBridgeRouter.sol";
+import "./libraries/Messages.sol";
+import "./libraries/WormholeExecutorMessages.sol";
+import "./libraries/Wormhole.sol";
+
+contract WormholeExecutorDataAdapter is IBridgeAdapter, IVaaV1Receiver, AccessControlDefaultAdminRules {
+    bytes32 public constant override MANAGER_ROLE = keccak256("MANAGER");
+
+    event ReceiveMessage(bytes32 indexed messageId, bytes32 adapterAddress);
+
+    error MessageParamsOverflow(uint256 value);
+    error InvalidTargetChain(uint16 wormholeChainId);
+    error InsufficientReceiverValue(uint128 expectedValue, uint256 receivedValue);
+
+    struct WormholeAdapterParams {
+        bool isAvailable;
+        uint16 wormholeChainId;
+        bytes32 adapterAddress;
+    }
+
+    mapping(uint16 folksChainId => WormholeAdapterParams) internal folksChainIdToWormholeAdapter;
+    mapping(uint16 wormholeChainId => uint16 folksChainId) internal wormholeChainIdToFolksChainId;
+
+    ICoreBridge public immutable wormhole;
+    uint16 public immutable thisWormholeChainId;
+    IExecutorQuoterRouter public immutable executorQuoterRouter;
+    IBridgeRouter public immutable bridgeRouter;
+    address public quoterAddress;
+    address public refundAddress;
+
+    modifier onlyBridgeRouter() {
+        if (msg.sender != address(bridgeRouter)) revert InvalidBridgeRouter(msg.sender);
+        _;
+    }
+
+    /**
+     * @notice Constructor
+     * @param admin The default admin for adapter
+     * @param _wormhole The Wormhole Core to get message fees
+     * @param _executorQuoterRouter The Executor to quote and request message execution
+     * @param _bridgeRouter The Bridge Router to route messages through
+     * @param _quoterAddress The address of the quoter
+     * @param _refundAddress The address to deliver any refund to
+     */
+    constructor(
+        address admin,
+        ICoreBridge _wormhole,
+        IExecutorQuoterRouter _executorQuoterRouter,
+        IBridgeRouter _bridgeRouter,
+        address _quoterAddress,
+        address _refundAddress
+    ) AccessControlDefaultAdminRules(1 days, admin) {
+        wormhole = _wormhole;
+        thisWormholeChainId = wormhole.chainId();
+        executorQuoterRouter = _executorQuoterRouter;
+        bridgeRouter = _bridgeRouter;
+        quoterAddress = _quoterAddress;
+        refundAddress = _refundAddress;
+        _grantRole(MANAGER_ROLE, admin);
+    }
+
+    function getSendFee(Messages.MessageToSend memory message) external view override returns (uint256 fee) {
+        // get chain adapter if available
+        (uint16 wormholeChainId, bytes32 adapterAddress) = getChainAdapter(message.destinationChainId);
+
+        // check for overflow
+        _checkMessageParamsOverflow(message.params);
+
+        // get executor quote
+        bytes memory requestBytes = RequestLib.encodeVaaMultiSigRequest(
+            thisWormholeChainId,
+            Messages.convertEVMAddressToGenericAddress(address(this)),
+            0 // sequence placeholder - not needed for quote
+        );
+        bytes memory relayInstructions = RelayInstructionLib.encodeGas(
+            uint128(message.params.gasLimit),
+            uint128(message.params.receiverValue)
+        );
+        uint256 executorFee = executorQuoterRouter.quoteExecution(
+            wormholeChainId,
+            adapterAddress,
+            refundAddress,
+            quoterAddress,
+            requestBytes,
+            relayInstructions
+        );
+
+        // add cost of publishing message
+        return executorFee + wormhole.messageFee();
+    }
+
+    function sendMessage(Messages.MessageToSend memory message) external payable override onlyBridgeRouter {
+        // get chain adapter if available
+        (uint16 wormholeChainId, bytes32 adapterAddress) = getChainAdapter(message.destinationChainId);
+
+        // check for overflow
+        _checkMessageParamsOverflow(message.params);
+
+        // ensure extra args is empty
+        if (message.extraArgs.length > 0) revert UnsupportedExtraArgs();
+
+        // prepare payload by adding metadata
+        bytes memory payloadWithMetadata = WormholeExecutorMessages.encodePayloadWithWormholeExecutorMetadata(
+            wormholeChainId,
+            uint128(message.params.receiverValue),
+            message
+        );
+
+        // publish message with nonce 0
+        uint8 consistencyLevel = Wormhole.getConsistencyLevel(message.finalityLevel);
+        uint256 messageFee = wormhole.messageFee();
+        uint64 sequence = wormhole.publishMessage{ value: messageFee }(0, payloadWithMetadata, consistencyLevel);
+
+        // request execution
+        bytes memory requestBytes = RequestLib.encodeVaaMultiSigRequest(
+            thisWormholeChainId,
+            Messages.convertEVMAddressToGenericAddress(address(this)),
+            sequence
+        );
+        bytes memory relayInstructions = RelayInstructionLib.encodeGas(
+            uint128(message.params.gasLimit),
+            uint128(message.params.receiverValue)
+        );
+
+        // send using wormhole relayer
+        uint256 executorFee = msg.value - messageFee;
+        executorQuoterRouter.requestExecution{ value: executorFee }(
+            wormholeChainId,
+            adapterAddress,
+            refundAddress,
+            quoterAddress,
+            requestBytes,
+            relayInstructions
+        );
+
+        emit SendMessage(bytes32(uint256(sequence)), message);
+    }
+
+    function executeVAAv1(bytes memory multiSigVaa) external payable override {
+        // skip unused timestamp, nonce, sequence and consistency level
+        (, , uint16 emitterChainId, bytes32 emitterAddress, , , bytes memory payload) = CoreBridgeLib
+            .decodeAndVerifyVaaMem(address(wormhole), multiSigVaa);
+
+        // check emitter chain and emitter address
+        uint16 folksChainId = wormholeChainIdToFolksChainId[emitterChainId];
+        (uint16 wormholeChainId, bytes32 adapterAddress) = getChainAdapter(folksChainId);
+        if (emitterChainId != wormholeChainId) revert ChainUnavailable(folksChainId);
+        if (adapterAddress != emitterAddress) revert InvalidMessageSender(emitterAddress);
+
+        // lib expects single hash but using double hash instead as that's what we are using for message id
+        bytes32 vaaHash = VaaLib.calcVaaDoubleHashMem(multiSigVaa);
+        HashReplayProtectionLib.replayProtect(vaaHash);
+
+        // decode into metadata and message payload
+        (
+            WormholeExecutorMessages.WormholeExecutorMetadata memory wormholeExecutorMetadata,
+            bytes memory messagePayload
+        ) = WormholeExecutorMessages.decodePayloadWithWormholeExecutorMetadata(payload);
+
+        // check that the destination chain is this and sufficient receiver value was passed
+        if (wormholeExecutorMetadata.wormholeTargetChainId != thisWormholeChainId)
+            revert InvalidTargetChain(wormholeExecutorMetadata.wormholeTargetChainId);
+        if (msg.value < wormholeExecutorMetadata.receiverValue)
+            revert InsufficientReceiverValue(wormholeExecutorMetadata.receiverValue, msg.value);
+
+        // construct and forward message to bridge router
+        Messages.MessageReceived memory messageReceived = Messages.MessageReceived({
+            messageId: vaaHash,
+            sourceChainId: folksChainId,
+            sourceAddress: wormholeExecutorMetadata.messageMetadata.sender,
+            handler: wormholeExecutorMetadata.messageMetadata.handler,
+            payload: messagePayload,
+            returnAdapterId: wormholeExecutorMetadata.messageMetadata.returnAdapterId,
+            returnGasLimit: wormholeExecutorMetadata.messageMetadata.returnGasLimit
+        });
+        bridgeRouter.receiveMessage{ value: msg.value }(messageReceived);
+
+        emit ReceiveMessage(messageReceived.messageId, adapterAddress);
+    }
+
+    function setQuoterAddress(address _quoterAddress) external onlyRole(MANAGER_ROLE) {
+        quoterAddress = _quoterAddress;
+    }
+
+    function setRefundAddress(address _refundAddress) external onlyRole(MANAGER_ROLE) {
+        refundAddress = _refundAddress;
+    }
+
+    function addChain(
+        uint16 folksChainId,
+        uint16 wormholeChainId,
+        bytes32 adapterAddress
+    ) external onlyRole(MANAGER_ROLE) {
+        // check if chain is already added
+        bool isAvailable = isChainAvailable(folksChainId);
+        if (isAvailable) revert ChainAlreadyAdded(folksChainId);
+
+        // add chain
+        folksChainIdToWormholeAdapter[folksChainId] = WormholeAdapterParams({
+            isAvailable: true,
+            wormholeChainId: wormholeChainId,
+            adapterAddress: adapterAddress
+        });
+        wormholeChainIdToFolksChainId[wormholeChainId] = folksChainId;
+    }
+
+    function removeChain(uint16 folksChainId) external onlyRole(MANAGER_ROLE) {
+        // get chain adapter if available
+        (uint16 wormholeChainId, ) = getChainAdapter(folksChainId);
+
+        // remove chain
+        delete folksChainIdToWormholeAdapter[folksChainId];
+        delete wormholeChainIdToFolksChainId[wormholeChainId];
+    }
+
+    function isChainAvailable(uint16 chainId) public view override returns (bool) {
+        return folksChainIdToWormholeAdapter[chainId].isAvailable;
+    }
+
+    function getChainAdapter(uint16 chainId) public view returns (uint16 wormholeChainId, bytes32 adapterAddress) {
+        WormholeAdapterParams memory chainAdapter = folksChainIdToWormholeAdapter[chainId];
+        if (!chainAdapter.isAvailable) revert ChainUnavailable(chainId);
+
+        wormholeChainId = chainAdapter.wormholeChainId;
+        adapterAddress = chainAdapter.adapterAddress;
+    }
+
+    function _checkMessageParamsOverflow(Messages.MessageParams memory params) internal pure {
+        if (params.gasLimit > type(uint128).max) revert MessageParamsOverflow(params.gasLimit);
+        if (params.receiverValue > type(uint128).max) revert MessageParamsOverflow(params.receiverValue);
+    }
+}

--- a/contracts/bridge/libraries/Wormhole.sol
+++ b/contracts/bridge/libraries/Wormhole.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 library Wormhole {
-    uint8 internal constant CONSISTENCY_LEVEL_FINALIZED = 15;
+    uint8 internal constant CONSISTENCY_LEVEL_FINALIZED = 1;
     uint8 internal constant CONSISTENCY_LEVEL_INSTANT = 200;
 
     function getConsistencyLevel(uint64 finalityLevel) internal pure returns (uint8) {

--- a/contracts/bridge/libraries/WormholeExecutorMessages.sol
+++ b/contracts/bridge/libraries/WormholeExecutorMessages.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import "@solidity-bytes-utils/contracts/BytesLib.sol";
+
+import "./Messages.sol";
+
+library WormholeExecutorMessages {
+    using BytesLib for bytes;
+
+    struct WormholeExecutorMetadata {
+        uint16 wormholeTargetChainId;
+        uint128 receiverValue;
+        Messages.MessageMetadata messageMetadata;
+    }
+
+    function encodePayloadWithWormholeExecutorMetadata(
+        uint16 wormholeTargetChainId,
+        uint128 receiverValue,
+        Messages.MessageToSend memory message
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                wormholeTargetChainId,
+                receiverValue,
+                message.params.returnAdapterId,
+                message.params.returnGasLimit,
+                message.sender,
+                message.handler,
+                message.payload
+            );
+    }
+
+    function decodePayloadWithWormholeExecutorMetadata(
+        bytes memory serialized
+    ) internal pure returns (WormholeExecutorMetadata memory wormholeExecutorMetadata, bytes memory payload) {
+        uint256 index = 0;
+        wormholeExecutorMetadata.wormholeTargetChainId = serialized.toUint16(index);
+        index += 2;
+        wormholeExecutorMetadata.receiverValue = serialized.toUint128(index);
+        index += 16;
+
+        Messages.MessageMetadata memory metadata;
+        metadata.returnAdapterId = serialized.toUint16(index);
+        index += 2;
+        metadata.returnGasLimit = serialized.toUint256(index);
+        index += 32;
+        metadata.sender = serialized.toBytes32(index);
+        index += 32;
+        metadata.handler = serialized.toBytes32(index);
+        index += 32;
+        wormholeExecutorMetadata.messageMetadata = metadata;
+
+        payload = serialized.slice(index, serialized.length - index);
+    }
+}

--- a/contracts/bridge/test/MockCircleMessageTransmitter.sol
+++ b/contracts/bridge/test/MockCircleMessageTransmitter.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.23;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@wormhole-solidity-sdk/interfaces/CCTPInterfaces/IMessageTransmitter.sol";
+import "wormhole-sdk/interfaces/cctp/IMessageTransmitter.sol";
 
 contract MockCircleMessageTransmitter is IMessageTransmitter {
-    event ReceiveMessage(bytes message, bytes signature);
+    event ReceiveMessage(bytes message, bytes attestation);
 
     bool private _success = true;
     address private _token;
@@ -29,6 +29,76 @@ contract MockCircleMessageTransmitter is IMessageTransmitter {
         _amount = newAmount;
     }
 
+    function attesterManager() external pure returns (address) {
+        return address(0);
+    }
+
+    function isEnabledAttester(address) external pure returns (bool) {
+        return false;
+    }
+
+    function getNumEnabledAttesters() external pure returns (uint256) {
+        return 0;
+    }
+
+    function getEnabledAttester(uint256) external pure returns (address) {
+        return address(0);
+    }
+
+    function updateAttesterManager(address) external {}
+
+    function setSignatureThreshold(uint256) external {}
+
+    function enableAttester(address) external {}
+
+    function disableAttester(address) external {}
+
+    function paused() external pure returns (bool) {
+        return false;
+    }
+
+    function pauser() external pure returns (address) {
+        return address(0);
+    }
+
+    function pause() external {}
+
+    function unpause() external {}
+
+    function updatePauser(address) external {}
+
+    function transferOwnership(address) external {}
+
+    function acceptOwnership() external override {}
+
+    function owner() external pure returns (address) {
+        return address(0);
+    }
+
+    function pendingOwner() external pure returns (address) {
+        return address(0);
+    }
+
+    function localDomain() external pure returns (uint32) {
+        return 0;
+    }
+
+    function version() external pure returns (uint32) {
+        return 0;
+    }
+
+    function maxMessageBodySize() external pure returns (uint256) {
+        return 0;
+    }
+
+    function nextAvailableNonce() external pure returns (uint64) {
+        return 0;
+    }
+
+    function usedNonces(bytes32) external pure returns (bool) {
+        return false;
+    }
+
     function sendMessage(uint32, bytes32, bytes calldata) external pure override returns (uint64) {
         return 0;
     }
@@ -39,9 +109,14 @@ contract MockCircleMessageTransmitter is IMessageTransmitter {
 
     function replaceMessage(bytes calldata, bytes calldata, bytes calldata, bytes32) external override {}
 
-    function receiveMessage(bytes calldata message, bytes calldata signature) external override returns (bool success) {
+    function receiveMessage(
+        bytes calldata message,
+        bytes calldata attestation
+    ) external override returns (bool success) {
         SafeERC20.safeTransfer(IERC20(_token), _recipient, _amount);
-        emit ReceiveMessage(message, signature);
+        emit ReceiveMessage(message, attestation);
         success = _success;
     }
+
+    function setMaxMessageBodySize(uint256 newMaxMessageBodySize) external {}
 }

--- a/contracts/bridge/test/MockCircleTokenMessenger.sol
+++ b/contracts/bridge/test/MockCircleTokenMessenger.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.23;
 
-import "@wormhole-solidity-sdk/interfaces/CCTPInterfaces/ITokenMessenger.sol";
+import "wormhole-sdk/interfaces/cctp/ITokenMessenger.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -20,6 +20,38 @@ contract MockCircleTokenMessenger is ITokenMessenger {
         _nonce = newNonce;
     }
 
+    function transferOwnership(address) external {}
+
+    function acceptOwnership() external override {}
+
+    function owner() external pure returns (address) {
+        return address(0);
+    }
+
+    function pendingOwner() external pure returns (address) {
+        return address(0);
+    }
+
+    function messageBodyVersion() external pure returns (uint32) {
+        return 0;
+    }
+
+    function localMessageTransmitter() external pure returns (IMessageTransmitter) {
+        return IMessageTransmitter(address(0));
+    }
+
+    function localMinter() external pure returns (ITokenMinter) {
+        return ITokenMinter(address(0));
+    }
+
+    function remoteTokenMessengers(uint32) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function depositForBurn(uint256, uint32, bytes32, address) external pure returns (uint64) {
+        return 0;
+    }
+
     function depositForBurnWithCaller(
         uint256 amount,
         uint32 destinationDomain,
@@ -31,4 +63,18 @@ contract MockCircleTokenMessenger is ITokenMessenger {
         emit DepositForBurnWithCaller(amount, destinationDomain, mintRecipient, burnToken, destinationCaller);
         nonce = _nonce;
     }
+
+    function replaceDepositForBurn(bytes calldata, bytes calldata, bytes32, bytes32) external {}
+
+    function handleReceiveMessage(uint32, bytes32, bytes calldata) external pure returns (bool) {
+        return false;
+    }
+
+    function addRemoteTokenMessenger(uint32, bytes32) external {}
+
+    function removeRemoteTokenMessenger(uint32) external {}
+
+    function addLocalMinter(address newLocalMinter) external {}
+
+    function removeLocalMinter() external {}
 }

--- a/contracts/bridge/test/MockExecutorQuoterRouter.sol
+++ b/contracts/bridge/test/MockExecutorQuoterRouter.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import { IExecutorQuoterRouter } from "wormhole-sdk/interfaces/IExecutor.sol";
+
+contract MockExecutorQuoterRouter is IExecutorQuoterRouter {
+    uint256 private _executorFee;
+
+    event RequestExecution(
+        uint256 msgValue,
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        address quoterAddr,
+        bytes requestBytes,
+        bytes relayInstructions
+    );
+
+    function setExecutorFee(uint256 newExecutorFee) external {
+        _executorFee = newExecutorFee;
+    }
+
+    function quoteExecution(
+        uint16,
+        bytes32,
+        address,
+        address,
+        bytes calldata,
+        bytes calldata
+    ) external view returns (uint256) {
+        return _executorFee;
+    }
+
+    function requestExecution(
+        uint16 dstChain,
+        bytes32 dstAddr,
+        address refundAddr,
+        address quoterAddr,
+        bytes calldata requestBytes,
+        bytes calldata relayInstructions
+    ) external payable {
+        emit RequestExecution(msg.value, dstChain, dstAddr, refundAddr, quoterAddr, requestBytes, relayInstructions);
+    }
+}

--- a/contracts/bridge/test/MockWormhole.sol
+++ b/contracts/bridge/test/MockWormhole.sol
@@ -1,96 +1,62 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.23;
 
-import "@wormhole-solidity-sdk/interfaces/IWormhole.sol";
+import "wormhole-sdk/interfaces/ICoreBridge.sol";
 
-contract MockWormhole is IWormhole {
+contract MockWormhole is ICoreBridge {
     uint256 private _messageFee;
+    uint64 private _sequence;
+    uint16 private _chainId;
+    GuardianSet private _guardianSet;
+
+    event PublishMessage(uint256 msgValue, uint32 nonce, bytes payload, uint8 consistencyLevel);
 
     function setMessageFee(uint256 newMessageFee) external {
         _messageFee = newMessageFee;
+    }
+
+    function setSequence(uint64 newSequence) external {
+        _sequence = newSequence;
+    }
+
+    function setChainId(uint16 newChainId) external {
+        _chainId = newChainId;
+    }
+
+    function setGuardianSet(GuardianSet memory newGuardianSet) external {
+        _guardianSet = newGuardianSet;
     }
 
     function messageFee() external view returns (uint256) {
         return _messageFee;
     }
 
-    function publishMessage(uint32, bytes memory, uint8) external payable returns (uint64 sequence) {}
-
-    function initialize() external {}
-
-    function parseAndVerifyVM(bytes calldata) external view returns (VM memory vm, bool valid, string memory reason) {}
-
-    function verifyVM(VM memory) external view returns (bool valid, string memory reason) {}
-
-    function verifySignatures(
-        bytes32 hash,
-        Signature[] memory,
-        GuardianSet memory
-    ) external pure returns (bool valid, string memory reason) {}
-
-    function parseVM(bytes memory) external pure returns (VM memory vm) {}
-
-    function quorum(uint256) external pure returns (uint256 numSignaturesRequiredForQuorum) {}
-
-    function getGuardianSet(uint32) external pure returns (GuardianSet memory) {}
-
-    function getCurrentGuardianSetIndex() external pure returns (uint32) {
-        return 0;
+    function publishMessage(
+        uint32 nonce,
+        bytes memory payload,
+        uint8 consistencyLevel
+    ) external payable returns (uint64 sequence) {
+        sequence = _sequence;
+        emit PublishMessage(msg.value, nonce, payload, consistencyLevel);
     }
 
-    function getGuardianSetExpiry() external pure returns (uint32) {
-        return 0;
-    }
+    function parseAndVerifyVM(
+        bytes calldata
+    ) external pure returns (CoreBridgeVM memory vm, bool valid, string memory reason) {}
 
-    function governanceActionIsConsumed(bytes32) external pure returns (bool) {
-        return false;
-    }
-
-    function isInitialized(address) external pure returns (bool) {
-        return false;
-    }
-
-    function chainId() external pure returns (uint16) {
-        return 0;
-    }
-
-    function isFork() external pure returns (bool) {
-        return false;
-    }
-
-    function governanceChainId() external pure returns (uint16) {
-        return 0;
-    }
-
-    function governanceContract() external pure returns (bytes32) {
-        return "";
-    }
-
-    function evmChainId() external pure returns (uint256) {
-        return 0;
+    function chainId() external view returns (uint16) {
+        return _chainId;
     }
 
     function nextSequence(address) external pure returns (uint64) {
         return 0;
     }
 
-    function parseContractUpgrade(bytes memory) external pure returns (ContractUpgrade memory) {}
+    function getGuardianSet(uint32) external view returns (GuardianSet memory) {
+        return _guardianSet;
+    }
 
-    function parseGuardianSetUpgrade(bytes memory) external pure returns (GuardianSetUpgrade memory gsu) {}
-
-    function parseSetMessageFee(bytes memory) external pure returns (SetMessageFee memory smf) {}
-
-    function parseTransferFees(bytes memory) external pure returns (TransferFees memory tf) {}
-
-    function parseRecoverChainId(bytes memory) external pure returns (RecoverChainId memory rci) {}
-
-    function submitContractUpgrade(bytes memory) external pure {}
-
-    function submitSetMessageFee(bytes memory) external pure {}
-
-    function submitNewGuardianSet(bytes memory) external pure {}
-
-    function submitTransferFees(bytes memory) external pure {}
-
-    function submitRecoverChainId(bytes memory) external pure {}
+    function getCurrentGuardianSetIndex() external pure returns (uint32) {
+        return 1;
+    }
 }

--- a/contracts/bridge/test/MockWormholeRelayer.sol
+++ b/contracts/bridge/test/MockWormholeRelayer.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.23;
 
-import "@wormhole-solidity-sdk/interfaces/IWormholeReceiver.sol";
-import "@wormhole-solidity-sdk/interfaces/IWormholeRelayer.sol";
+import "wormhole-sdk/interfaces/IWormholeRelayer.sol";
 
 contract MockWormholeRelayer is IWormholeRelayer {
     event WormholeSendVaaKey(

--- a/contracts/hub-rewards/HubRewardsV2.sol
+++ b/contracts/hub-rewards/HubRewardsV2.sol
@@ -313,9 +313,9 @@ contract HubRewardsV2 is AccessControlDefaultAdminRules, BridgeMessenger {
             uint256 gasLimit = payload.data.toUint256(index);
             index += 32;
 
-            bytes32 accountId = payload.accountId; // avoid stack too deep error
             uint16 chainId = rewardTokens[rewardTokenId].chainId;
             bytes32 spokeAddress = rewardTokens[rewardTokenId].spokeAddress;
+            bytes32 accountId = payload.accountId; // avoid stack too deep error
             bytes32 recipient = accountManager.getAddressRegisteredToAccountOnChain(accountId, chainId);
             uint256 amount = accountUnclaimedRewards[accountId][rewardTokenId];
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'cache_forge'
 evm_version = 'paris'
+via_ir = true
 optimizer = true
 optimizer_runs = 200
 ignored_error_codes = []

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,6 +11,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 200,
       },
+      viaIR: true,
     },
   },
   defaultNetwork: "hardhat",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
 @solidity-bytes-utils/=node_modules/solidity-bytes-utils/
-@wormhole-solidity-sdk/=lib/wormhole-solidity-sdk/src/
+wormhole-sdk/=lib/wormhole-solidity-sdk/src/

--- a/test/bridge/WormholeExecutorDataAdapter.test.ts
+++ b/test/bridge/WormholeExecutorDataAdapter.test.ts
@@ -1,0 +1,757 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import {
+  BridgeRouterSender__factory,
+  MockWormhole__factory,
+  MockExecutorQuoterRouter__factory,
+  WormholeExecutorDataAdapter__factory,
+} from "../../typechain-types";
+import {
+  BYTES32_LENGTH,
+  convertEVMAddressToGenericAddress,
+  convertNumberToBytes,
+  convertStringToBytes,
+  getAccountIdBytes,
+  getEmptyBytes,
+  getRandomAddress,
+  MAX_UINT128,
+  UINT16_LENGTH,
+  UINT256_LENGTH,
+} from "../utils/bytes";
+import { encodeGas, encodeVaaMultiSigRequest } from "../utils/messages/executor";
+import { Finality, MessageParams, MessageToSend, buildMessagePayload } from "../utils/messages/messages";
+import { encodeWormholeVAA } from "../utils/messages/wormhole";
+import { encodePayloadWithWormholeExecutorMetadata } from "../utils/messages/wormholeExecutorMessages";
+import { SECONDS_IN_DAY, getLatestBlockTimestamp, getRandomInt } from "../utils/time";
+import { WormholeFinality } from "../utils/wormhole";
+
+describe("WormholeExecutorDataAdapter (unit tests)", () => {
+  const DEFAULT_ADMIN_ROLE = getEmptyBytes(BYTES32_LENGTH);
+  const MANAGER_ROLE = ethers.keccak256(convertStringToBytes("MANAGER"));
+
+  const WH_CHAIN_ID = 2;
+  const GUARDIAN = ethers.Wallet.createRandom();
+
+  const getMessageParams = (): MessageParams => ({
+    adapterId: BigInt(0),
+    receiverValue: BigInt(0.1e18),
+    gasLimit: BigInt(500_000),
+    returnAdapterId: BigInt(0),
+    returnGasLimit: BigInt(0),
+  });
+
+  const getMessage = (destChainId: number): MessageToSend => ({
+    params: getMessageParams(),
+    sender: convertEVMAddressToGenericAddress(getRandomAddress()),
+    destinationChainId: BigInt(destChainId),
+    handler: convertEVMAddressToGenericAddress(getRandomAddress()),
+    payload: buildMessagePayload(0, getAccountIdBytes("ACCOUNT_ID"), getRandomAddress(), "0x"),
+    finalityLevel: Finality.IMMEDIATE,
+    extraArgs: "0x",
+  });
+
+  async function deployWormholeExecutorDataAdapterFixture() {
+    const [user, admin, ...unusedUsers] = await ethers.getSigners();
+
+    // deploy mock wormhole core
+    const wormhole = await new MockWormhole__factory(admin).deploy();
+    await wormhole.setChainId(WH_CHAIN_ID);
+    await wormhole.setGuardianSet({
+      keys: [GUARDIAN.address],
+      expirationTime: (await getLatestBlockTimestamp()) + SECONDS_IN_DAY,
+    });
+
+    // deploy adapter
+    const executorQuoterRouter = await new MockExecutorQuoterRouter__factory(admin).deploy();
+    const bridgeRouter = await new BridgeRouterSender__factory(admin).deploy();
+    const quoterAddress = getRandomAddress();
+    const refundAddress = getRandomAddress();
+    const adapter = await new WormholeExecutorDataAdapter__factory(user).deploy(
+      admin,
+      wormhole,
+      executorQuoterRouter,
+      bridgeRouter,
+      quoterAddress,
+      refundAddress
+    );
+    await bridgeRouter.setAdapter(adapter);
+
+    return {
+      user,
+      admin,
+      unusedUsers,
+      adapter,
+      wormhole,
+      executorQuoterRouter,
+      bridgeRouter,
+      quoterAddress,
+      refundAddress,
+    };
+  }
+
+  async function addChainFixture() {
+    const {
+      user,
+      admin,
+      unusedUsers,
+      adapter,
+      wormhole,
+      executorQuoterRouter,
+      bridgeRouter,
+      quoterAddress,
+      refundAddress,
+    } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+    // add chain
+    const corrFolksChainId = 0;
+    const corrWormholeChainId = 5;
+    const corrAdapterAddress = convertEVMAddressToGenericAddress(getRandomAddress());
+    await adapter.connect(admin).addChain(corrFolksChainId, corrWormholeChainId, corrAdapterAddress);
+
+    return {
+      user,
+      admin,
+      unusedUsers,
+      adapter,
+      wormhole,
+      executorQuoterRouter,
+      bridgeRouter,
+      quoterAddress,
+      refundAddress,
+      corrFolksChainId,
+      corrWormholeChainId,
+      corrAdapterAddress,
+    };
+  }
+
+  describe("Deployment", () => {
+    it("Should set admin, relayer and bridge router correctly", async () => {
+      const { admin, adapter, wormhole, executorQuoterRouter, bridgeRouter, quoterAddress, refundAddress } =
+        await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // check default admin role
+      expect(await adapter.owner()).to.equal(admin.address);
+      expect(await adapter.defaultAdmin()).to.equal(admin.address);
+      expect(await adapter.defaultAdminDelay()).to.equal(SECONDS_IN_DAY);
+      expect(await adapter.getRoleAdmin(DEFAULT_ADMIN_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+      expect(await adapter.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be.true;
+
+      // check manager role
+      expect(await adapter.getRoleAdmin(MANAGER_ROLE)).to.equal(DEFAULT_ADMIN_ROLE);
+      expect(await adapter.hasRole(MANAGER_ROLE, admin.address)).to.be.true;
+
+      // check state
+      expect(await adapter.wormhole()).to.equal(wormhole);
+      expect(await adapter.thisWormholeChainId()).to.equal(WH_CHAIN_ID);
+      expect(await adapter.executorQuoterRouter()).to.equal(executorQuoterRouter);
+      expect(await adapter.bridgeRouter()).to.equal(bridgeRouter);
+      expect(await adapter.quoterAddress()).to.equal(quoterAddress);
+      expect(await adapter.refundAddress()).to.equal(refundAddress);
+    });
+  });
+
+  describe("Set Quoter Address", () => {
+    it("Should successfully set quoter address", async () => {
+      const { admin, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // set quoter address
+      const quoterAddress = getRandomAddress();
+      await adapter.connect(admin).setQuoterAddress(quoterAddress);
+      expect(await adapter.quoterAddress()).to.equal(quoterAddress);
+    });
+
+    it("Should fail to set quoter address when sender is not manager", async () => {
+      const { user, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      const quoterAddress = getRandomAddress();
+
+      // set refund address
+      const setQuoterAddress = adapter.connect(user).setQuoterAddress(quoterAddress);
+      await expect(setQuoterAddress)
+        .to.be.revertedWithCustomError(adapter, "AccessControlUnauthorizedAccount")
+        .withArgs(user.address, MANAGER_ROLE);
+    });
+  });
+
+  describe("Set Refund Address", () => {
+    it("Should successfully set refund address", async () => {
+      const { admin, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // set refund address
+      const refundAddress = getRandomAddress();
+      await adapter.connect(admin).setRefundAddress(refundAddress);
+      expect(await adapter.refundAddress()).to.equal(refundAddress);
+    });
+
+    it("Should fail to set refund address when sender is not manager", async () => {
+      const { user, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      const refundAddress = getRandomAddress();
+
+      // set refund address
+      const setRefundAddress = adapter.connect(user).setRefundAddress(refundAddress);
+      await expect(setRefundAddress)
+        .to.be.revertedWithCustomError(adapter, "AccessControlUnauthorizedAccount")
+        .withArgs(user.address, MANAGER_ROLE);
+    });
+  });
+
+  describe("Add Chain", () => {
+    it("Should successfully add chain", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // verfy added
+      expect(await adapter.isChainAvailable(corrFolksChainId)).to.be.true;
+      expect(await adapter.getChainAdapter(corrFolksChainId)).to.be.eql([
+        BigInt(corrWormholeChainId),
+        corrAdapterAddress,
+      ]);
+    });
+
+    it("Should fail to add chain when sender is not manager", async () => {
+      const { user, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      const folksChainId = 0;
+      const wormholeChainId = 5;
+      const corrAdapterAddress = convertEVMAddressToGenericAddress(getRandomAddress());
+
+      // add chain
+      const addChain = adapter.connect(user).addChain(folksChainId, wormholeChainId, corrAdapterAddress);
+      await expect(addChain)
+        .to.be.revertedWithCustomError(adapter, "AccessControlUnauthorizedAccount")
+        .withArgs(user.address, MANAGER_ROLE);
+    });
+
+    it("Should fail to add chain when already added", async () => {
+      const { admin, adapter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      const corrWormholeChainId = 3;
+      const corrAdapterAddress = convertEVMAddressToGenericAddress(getRandomAddress());
+
+      // verify added
+      expect(await adapter.isChainAvailable(corrFolksChainId)).to.be.true;
+
+      // add chain
+      const addChain = adapter.connect(admin).addChain(corrFolksChainId, corrWormholeChainId, corrAdapterAddress);
+      await expect(addChain).to.be.revertedWithCustomError(adapter, "ChainAlreadyAdded").withArgs(corrFolksChainId);
+    });
+  });
+
+  describe("Remove Chain", () => {
+    it("Should successfully remove chain", async () => {
+      const { admin, adapter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      // remove chain
+      await adapter.connect(admin).removeChain(corrFolksChainId);
+      expect(await adapter.isChainAvailable(corrFolksChainId)).to.be.false;
+    });
+
+    it("Should fail to remove chain when sender is not manager", async () => {
+      const { user, adapter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      // remove chain
+      const removeChain = adapter.connect(user).removeChain(corrFolksChainId);
+      await expect(removeChain)
+        .to.be.revertedWithCustomError(adapter, "AccessControlUnauthorizedAccount")
+        .withArgs(user.address, MANAGER_ROLE);
+    });
+
+    it("Should fail to remove chain when not added", async () => {
+      const { admin, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // verify not added
+      const folksChainId = 0;
+      expect(await adapter.isChainAvailable(folksChainId)).to.be.false;
+
+      // add chain
+      const removeChain = adapter.connect(admin).removeChain(folksChainId);
+      await expect(removeChain).to.be.revertedWithCustomError(adapter, "ChainUnavailable").withArgs(folksChainId);
+    });
+  });
+
+  describe("Get Chain Adapter", () => {
+    it("Should fail when chain not added", async () => {
+      const { admin, adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // verify not added
+      const corrFolksChainId = 0;
+      expect(await adapter.isChainAvailable(corrFolksChainId)).to.be.false;
+
+      // get chain adapter
+      const getChainAdapter = adapter.connect(admin).getChainAdapter(corrFolksChainId);
+      await expect(getChainAdapter)
+        .to.be.revertedWithCustomError(adapter, "ChainUnavailable")
+        .withArgs(corrFolksChainId);
+    });
+  });
+
+  describe("Get Send Fee", () => {
+    it("Should successfully get send fee", async () => {
+      const { adapter, wormhole, executorQuoterRouter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      // set publish fee
+      const publishFee = BigInt(getRandomInt(100_000));
+      await wormhole.setMessageFee(publishFee);
+
+      // set executor fee
+      const executorFee = BigInt(getRandomInt(500_000));
+      await executorQuoterRouter.setExecutorFee(executorFee);
+
+      // get send fee
+      const message = getMessage(corrFolksChainId);
+      const fee = await adapter.getSendFee(message);
+      expect(fee).to.be.equal(publishFee + executorFee);
+    });
+
+    it("Should fail to get send fee when message params gas limit overflows", async () => {
+      const { adapter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      const message = getMessage(corrFolksChainId);
+      const gasLimit = MAX_UINT128 + BigInt(1);
+      message.params.gasLimit = gasLimit;
+
+      const getSendFee = adapter.getSendFee(message);
+      await expect(getSendFee).to.be.revertedWithCustomError(adapter, "MessageParamsOverflow").withArgs(gasLimit);
+    });
+
+    it("Should fail to get send fee when message params receiver value overflows", async () => {
+      const { adapter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      const message = getMessage(corrFolksChainId);
+      const receiverValue = MAX_UINT128 + BigInt(1);
+      message.params.receiverValue = receiverValue;
+
+      const getSendFee = adapter.getSendFee(message);
+      await expect(getSendFee).to.be.revertedWithCustomError(adapter, "MessageParamsOverflow").withArgs(receiverValue);
+    });
+
+    it("Should fail to get send fee when chain not added", async () => {
+      const { adapter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // verify not added
+      const folksChainId = 0;
+      expect(await adapter.isChainAvailable(folksChainId)).to.be.false;
+      const message = getMessage(folksChainId);
+
+      // get send fee
+      const getSendFee = adapter.getSendFee(message);
+      await expect(getSendFee).to.be.revertedWithCustomError(adapter, "ChainUnavailable").withArgs(folksChainId);
+    });
+  });
+
+  describe("Send Message", () => {
+    it("Should successfully send immediate finality message", async () => {
+      const {
+        adapter,
+        wormhole,
+        executorQuoterRouter,
+        bridgeRouter,
+        quoterAddress,
+        refundAddress,
+        corrFolksChainId,
+        corrWormholeChainId,
+        corrAdapterAddress,
+      } = await loadFixture(addChainFixture);
+
+      // balances before
+      const adapterBalance = await ethers.provider.getBalance(adapter);
+      const wormholeBalance = await ethers.provider.getBalance(wormhole);
+      const executorQuoterRouterBalance = await ethers.provider.getBalance(executorQuoterRouter);
+
+      // get fee
+      const message = getMessage(corrFolksChainId);
+      message.finalityLevel = Finality.IMMEDIATE;
+      const totalFee = await bridgeRouter.getSendFee(message);
+      const publishFee = await wormhole.messageFee();
+      const executorFee = totalFee - publishFee;
+
+      // set sequence
+      const sequence = getRandomInt(1000);
+      await wormhole.setSequence(sequence);
+
+      // send message
+      const sendMessage = bridgeRouter.sendMessage(message, { value: totalFee });
+      await expect(sendMessage)
+        .to.emit(adapter, "SendMessage")
+        .withArgs(convertNumberToBytes(sequence, BYTES32_LENGTH), anyValue);
+      await expect(sendMessage)
+        .to.emit(wormhole, "PublishMessage")
+        .withArgs(
+          publishFee,
+          0,
+          encodePayloadWithWormholeExecutorMetadata(corrWormholeChainId, message),
+          WormholeFinality.INSTANT
+        );
+      await expect(sendMessage)
+        .to.emit(executorQuoterRouter, "RequestExecution")
+        .withArgs(
+          executorFee,
+          corrWormholeChainId,
+          corrAdapterAddress,
+          refundAddress,
+          quoterAddress,
+          encodeVaaMultiSigRequest(
+            WH_CHAIN_ID,
+            convertEVMAddressToGenericAddress(await adapter.getAddress()),
+            sequence
+          ),
+          encodeGas(message.params.gasLimit, message.params.receiverValue)
+        );
+
+      // balances after
+      expect(await ethers.provider.getBalance(adapter)).to.equal(adapterBalance);
+      expect(await ethers.provider.getBalance(wormhole)).to.equal(wormholeBalance + publishFee);
+      expect(await ethers.provider.getBalance(executorQuoterRouter)).to.equal(
+        executorQuoterRouterBalance + executorFee
+      );
+    });
+
+    it("Should successfully send finalised finality message", async () => {
+      const {
+        adapter,
+        wormhole,
+        executorQuoterRouter,
+        bridgeRouter,
+        quoterAddress,
+        refundAddress,
+        corrFolksChainId,
+        corrWormholeChainId,
+        corrAdapterAddress,
+      } = await loadFixture(addChainFixture);
+
+      // get fee
+      const message = getMessage(corrFolksChainId);
+      message.finalityLevel = Finality.FINALISED;
+      const totalFee = await bridgeRouter.getSendFee(message);
+      const publishFee = await wormhole.messageFee();
+      const executorFee = totalFee - publishFee;
+
+      // set sequence
+      const sequence = getRandomInt(1000);
+      await wormhole.setSequence(sequence);
+
+      // send message
+      const sendMessage = bridgeRouter.sendMessage(message, { value: totalFee });
+      await expect(sendMessage)
+        .to.emit(adapter, "SendMessage")
+        .withArgs(convertNumberToBytes(sequence, BYTES32_LENGTH), anyValue);
+      await expect(sendMessage)
+        .to.emit(wormhole, "PublishMessage")
+        .withArgs(
+          publishFee,
+          0,
+          encodePayloadWithWormholeExecutorMetadata(corrWormholeChainId, message),
+          WormholeFinality.FINALIZED
+        );
+      await expect(sendMessage)
+        .to.emit(executorQuoterRouter, "RequestExecution")
+        .withArgs(
+          executorFee,
+          corrWormholeChainId,
+          corrAdapterAddress,
+          refundAddress,
+          quoterAddress,
+          encodeVaaMultiSigRequest(
+            WH_CHAIN_ID,
+            convertEVMAddressToGenericAddress(await adapter.getAddress()),
+            sequence
+          ),
+          encodeGas(message.params.gasLimit, message.params.receiverValue)
+        );
+    });
+
+    it("Should fail to send message when sender is not bridge router", async () => {
+      const { user, adapter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      // get fee
+      const message = getMessage(corrFolksChainId);
+      const fee = await adapter.getSendFee(message);
+
+      // send message
+      const sendMessage = adapter.connect(user).sendMessage(message, { value: fee });
+      await expect(sendMessage).to.be.revertedWithCustomError(adapter, "InvalidBridgeRouter").withArgs(user.address);
+    });
+
+    it("Should fail to send message when chain not added", async () => {
+      const { adapter, bridgeRouter } = await loadFixture(deployWormholeExecutorDataAdapterFixture);
+
+      // verify not added
+      const corrFolksChainId = 0;
+      expect(await adapter.isChainAvailable(corrFolksChainId)).to.be.false;
+
+      // get fee
+      const message = getMessage(corrFolksChainId);
+      const fee = 10000;
+
+      // send message
+      const sendMessage = bridgeRouter.sendMessage(message, { value: fee });
+      await expect(sendMessage).to.be.revertedWithCustomError(adapter, "ChainUnavailable").withArgs(corrFolksChainId);
+    });
+
+    it("Should fail to send message when message params gas limit overflows", async () => {
+      const { adapter, bridgeRouter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      const message = getMessage(corrFolksChainId);
+      const gasLimit = MAX_UINT128 + BigInt(1);
+      message.params.gasLimit = gasLimit;
+
+      const sendMessage = bridgeRouter.sendMessage(message);
+      await expect(sendMessage).to.be.revertedWithCustomError(adapter, "MessageParamsOverflow").withArgs(gasLimit);
+    });
+
+    it("Should fail to send message when message params receiver value overflows", async () => {
+      const { adapter, bridgeRouter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      const message = getMessage(corrFolksChainId);
+      const receiverValue = MAX_UINT128 + BigInt(1);
+      message.params.receiverValue = receiverValue;
+
+      const sendMessage = bridgeRouter.sendMessage(message);
+      await expect(sendMessage).to.be.revertedWithCustomError(adapter, "MessageParamsOverflow").withArgs(receiverValue);
+    });
+
+    it("Should fail to send message when extra args is used", async () => {
+      const { adapter, bridgeRouter, corrFolksChainId } = await loadFixture(addChainFixture);
+
+      // get fee
+      const message = getMessage(corrFolksChainId);
+      message.extraArgs = "0x00";
+      const fee = await adapter.getSendFee(message);
+
+      // send message
+      const sendMessage = bridgeRouter.sendMessage(message, { value: fee });
+      await expect(sendMessage).to.be.revertedWithCustomError(adapter, "UnsupportedExtraArgs");
+    });
+  });
+
+  describe("Execute VAA v1", () => {
+    it("Should successfully receive message", async () => {
+      const { adapter, bridgeRouter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } =
+        await loadFixture(addChainFixture);
+
+      // balances before
+      const adapterBalance = await ethers.provider.getBalance(adapter);
+      const bridgeRouterBalance = await ethers.provider.getBalance(bridgeRouter);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const receiverValue = BigInt(getRandomInt(1e18));
+      message.params.receiverValue = receiverValue;
+      const { digest, vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message)
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa, { value: receiverValue });
+      await expect(receiveMessage)
+        .to.emit(adapter, "ReceiveMessage(bytes32,bytes32)")
+        .withArgs(digest, corrAdapterAddress);
+      await expect(receiveMessage)
+        .to.emit(bridgeRouter, "MessageReceived")
+        .withArgs(
+          Object.values([
+            digest,
+            convertNumberToBytes(corrFolksChainId, UINT16_LENGTH),
+            message.sender,
+            message.handler,
+            message.payload,
+            convertNumberToBytes(message.params.returnAdapterId, UINT16_LENGTH),
+            convertNumberToBytes(message.params.returnGasLimit, UINT256_LENGTH),
+          ])
+        );
+
+      // balances after
+      expect(await ethers.provider.getBalance(adapter)).to.equal(adapterBalance);
+      expect(await ethers.provider.getBalance(bridgeRouter)).to.equal(bridgeRouterBalance + receiverValue);
+    });
+
+    it("Should fail to receive message when vaa version is not 1", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const vaaVersion = 2;
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message),
+        vaaVersion
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa);
+      await expect(receiveMessage).to.be.revertedWithCustomError(adapter, "UnexpectedVersion").withArgs(vaaVersion);
+    });
+
+    it("Should fail to receive message when insufficient number of guardian signatures", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message),
+        undefined,
+        true
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa);
+      await expect(receiveMessage).to.be.revertedWithCustomError(adapter, "VerificationFailed");
+    });
+
+    it("Should fail to receive message when guardian signature is invalid", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message),
+        undefined,
+        false,
+        true
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa);
+      await expect(receiveMessage).to.be.revertedWithCustomError(adapter, "VerificationFailed");
+    });
+
+    it("Should fail to receive message when chain when not added", async () => {
+      const { adapter, corrFolksChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // verify chain unknown
+      const corrWormholeChainId = 4;
+      expect((await adapter.getChainAdapter(corrFolksChainId))[0]).to.not.equal(corrWormholeChainId);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message)
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa, { value: message.params.receiverValue });
+      await expect(receiveMessage)
+        .to.be.revertedWithCustomError(adapter, "ChainUnavailable")
+        .withArgs(corrFolksChainId);
+    });
+
+    it("Should fail to receive message when message sender is not corresponding adapter", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId } = await loadFixture(addChainFixture);
+
+      // verify sender unknown
+      const corrAdapterAddress = convertEVMAddressToGenericAddress(getRandomAddress());
+      expect((await adapter.getChainAdapter(corrFolksChainId))[1]).to.not.equal(corrAdapterAddress);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message)
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa, { value: message.params.receiverValue });
+      await expect(receiveMessage)
+        .to.be.revertedWithCustomError(adapter, "InvalidMessageSender")
+        .withArgs(corrAdapterAddress);
+    });
+
+    it("Should fail to receive message already processed", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message)
+      );
+
+      // receive message twice
+      await adapter.executeVAAv1(vaa, { value: message.params.receiverValue });
+      const receiveMessage = adapter.executeVAAv1(vaa, { value: message.params.receiverValue });
+      await expect(receiveMessage).to.be.revertedWithCustomError(adapter, "AlreadyProcessed");
+    });
+
+    it("Should fail to receive message intended for different chain", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // verify incorrect target chain
+      const emitterChainId = 42;
+      expect(await adapter.thisWormholeChainId()).to.not.equal(emitterChainId);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(emitterChainId, message)
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa, { value: message.params.receiverValue });
+      await expect(receiveMessage)
+        .to.be.revertedWithCustomError(adapter, "InvalidTargetChain")
+        .withArgs(emitterChainId);
+    });
+
+    it("Should fail to receive message with insufficient receiver value", async () => {
+      const { adapter, corrFolksChainId, corrWormholeChainId, corrAdapterAddress } = await loadFixture(addChainFixture);
+
+      // construct message
+      const message = getMessage(corrFolksChainId);
+      const receiverValue = BigInt(getRandomInt(1e18));
+      message.params.receiverValue = receiverValue;
+      const { vaa } = encodeWormholeVAA(
+        GUARDIAN,
+        corrWormholeChainId,
+        corrAdapterAddress,
+        getRandomInt(1000),
+        WormholeFinality.FINALIZED,
+        encodePayloadWithWormholeExecutorMetadata(WH_CHAIN_ID, message)
+      );
+
+      // receive message
+      const receiveMessage = adapter.executeVAAv1(vaa, { value: receiverValue - BigInt(1) });
+      await expect(receiveMessage)
+        .to.be.revertedWithCustomError(adapter, "InsufficientReceiverValue")
+        .withArgs(receiverValue, receiverValue - BigInt(1));
+    });
+  });
+});

--- a/test/utils/bytes.ts
+++ b/test/utils/bytes.ts
@@ -4,9 +4,12 @@ export const UINT8_LENGTH = 1;
 export const UINT16_LENGTH = 2;
 export const UINT32_LENGTH = 4;
 export const UINT64_LENGTH = 8;
+export const UINT128_LENGTH = 16;
 export const UINT256_LENGTH = 32;
 export const BYTES4_LENGTH = 4;
 export const BYTES32_LENGTH = 32;
+
+export const MAX_UINT128 = 2n ** 128n - 1n;
 
 export const EVM_ADDRESS_BYTES_LENGTH = 20;
 

--- a/test/utils/messages/executor.ts
+++ b/test/utils/messages/executor.ts
@@ -1,0 +1,34 @@
+import { ethers } from "hardhat";
+import {
+  BYTES32_LENGTH,
+  UINT128_LENGTH,
+  UINT16_LENGTH,
+  UINT64_LENGTH,
+  UINT8_LENGTH,
+  convertNumberToBytes,
+  convertStringToBytes,
+} from "../bytes";
+
+const REQ_VAA_V1 = convertStringToBytes("ERV1");
+const RECV_INST_TYPE_GAS = convertNumberToBytes(1, UINT8_LENGTH);
+
+export function encodeVaaMultiSigRequest(
+  emitterChainId: number | bigint,
+  emitterAddress: string,
+  sequence: number | bigint
+): string {
+  return ethers.concat([
+    REQ_VAA_V1,
+    convertNumberToBytes(emitterChainId, UINT16_LENGTH),
+    emitterAddress,
+    convertNumberToBytes(sequence, UINT64_LENGTH),
+  ]);
+}
+
+export function encodeGas(gasLimit: number | bigint, msgValue: number | bigint): string {
+  return ethers.concat([
+    RECV_INST_TYPE_GAS,
+    convertNumberToBytes(gasLimit, UINT128_LENGTH),
+    convertNumberToBytes(msgValue, UINT128_LENGTH),
+  ]);
+}

--- a/test/utils/messages/wormhole.ts
+++ b/test/utils/messages/wormhole.ts
@@ -1,0 +1,64 @@
+import { ethers } from "hardhat";
+import { BaseWallet } from "ethers";
+import {
+  UINT16_LENGTH,
+  UINT32_LENGTH,
+  UINT64_LENGTH,
+  UINT8_LENGTH,
+  convertNumberToBytes,
+  getRandomBytes,
+} from "../bytes";
+import { WormholeFinality } from "../wormhole";
+
+const NUM_SIGNATURES = 1;
+const SIGNATURE_RECOVERY_MAGIC = 27;
+
+// only supports 1 signature
+export function encodeWormholeVAA(
+  guardian: BaseWallet,
+  emitterChainId: number | bigint,
+  emitterAddress: string,
+  sequence: number | bigint,
+  consistencyLevel: WormholeFinality,
+  payload: string,
+  vaaVersion = 1,
+  skipSignatures = false,
+  incorrectSignature = false
+): { digest: string; vaa: string } {
+  const body = ethers.concat([
+    convertNumberToBytes(0, UINT32_LENGTH), // timestamp
+    convertNumberToBytes(0, UINT32_LENGTH), // nonce
+    convertNumberToBytes(emitterChainId, UINT16_LENGTH),
+    emitterAddress,
+    convertNumberToBytes(sequence, UINT64_LENGTH),
+    convertNumberToBytes(consistencyLevel, UINT8_LENGTH),
+    payload,
+  ]);
+
+  const digest = ethers.keccak256(ethers.keccak256(body));
+  const signature = guardian.signingKey.sign(digest);
+  const signatureBytes = incorrectSignature
+    ? getRandomBytes(65)
+    : ethers.concat([
+        signature.r,
+        signature.s,
+        // https://github.com/wormhole-foundation/wormhole/blob/c35940ae9689f6df9e983d51425763509b74a80f/ethereum/contracts/Messages.sol#L174
+        convertNumberToBytes(signature.v - SIGNATURE_RECOVERY_MAGIC, UINT8_LENGTH),
+      ]);
+  const signaturesBytes = skipSignatures
+    ? convertNumberToBytes(0, UINT8_LENGTH)
+    : ethers.concat([
+        convertNumberToBytes(NUM_SIGNATURES, UINT8_LENGTH),
+        convertNumberToBytes(0, UINT8_LENGTH), // index of guardian in the guardian set
+        signatureBytes,
+      ]);
+
+  const header = ethers.concat([
+    convertNumberToBytes(vaaVersion, UINT8_LENGTH), // version
+    convertNumberToBytes(1, UINT32_LENGTH), // guardian set index
+    signaturesBytes,
+  ]);
+
+  const vaa = ethers.concat([header, body]);
+  return { digest, vaa };
+}

--- a/test/utils/messages/wormholeExecutorMessages.ts
+++ b/test/utils/messages/wormholeExecutorMessages.ts
@@ -1,0 +1,54 @@
+import { ethers } from "hardhat";
+import { BYTES32_LENGTH, UINT128_LENGTH, UINT16_LENGTH, UINT256_LENGTH, convertNumberToBytes } from "../bytes";
+import { MessageToSend, MessageMetadata } from "./messages";
+
+export function encodePayloadWithWormholeExecutorMetadata(
+  wormholeTargetChainId: number | bigint,
+  message: MessageToSend
+): string {
+  return ethers.concat([
+    convertNumberToBytes(wormholeTargetChainId, UINT16_LENGTH),
+    convertNumberToBytes(message.params.receiverValue, UINT128_LENGTH),
+    convertNumberToBytes(message.params.returnAdapterId, UINT16_LENGTH),
+    convertNumberToBytes(message.params.returnGasLimit, UINT256_LENGTH),
+    message.sender,
+    message.handler,
+    message.payload,
+  ]);
+}
+
+export interface WormholeExecutorMetadata {
+  wormholeTargetChainId: bigint;
+  receiverValue: bigint;
+  messageMetadata: MessageMetadata;
+}
+
+export interface PayloadWithWormholeExecutorMetadata {
+  metadata: WormholeExecutorMetadata;
+  payload: string;
+}
+
+export function decodePayloadWithWormholeExecutorMetadata(serialised: string): PayloadWithWormholeExecutorMetadata {
+  let index = 0;
+  const wormholeTargetChainId = BigInt(parseInt(ethers.dataSlice(serialised, index, index + UINT16_LENGTH), 16));
+  index += UINT16_LENGTH;
+  const receiverValue = BigInt(parseInt(ethers.dataSlice(serialised, index, index + UINT128_LENGTH), 16));
+  index += UINT128_LENGTH;
+  const returnAdapterId = BigInt(parseInt(ethers.dataSlice(serialised, index, index + UINT16_LENGTH), 16));
+  index += UINT16_LENGTH;
+  const returnGasLimit = BigInt(parseInt(ethers.dataSlice(serialised, index, index + UINT256_LENGTH), 16));
+  index += UINT256_LENGTH;
+  const sender = ethers.dataSlice(serialised, index, index + BYTES32_LENGTH);
+  index += BYTES32_LENGTH;
+  const handler = ethers.dataSlice(serialised, index, index + BYTES32_LENGTH);
+  index += BYTES32_LENGTH;
+  const payload = ethers.dataSlice(serialised, index);
+  return {
+    metadata: {
+      wormholeTargetChainId,
+      receiverValue,
+      messageMetadata: { returnAdapterId, returnGasLimit, sender, handler },
+    },
+    payload,
+  };
+}

--- a/test/utils/wormhole.ts
+++ b/test/utils/wormhole.ts
@@ -1,4 +1,4 @@
 export enum WormholeFinality {
   INSTANT = 200,
-  FINALIZED = 15,
+  FINALIZED = 1,
 }


### PR DESCRIPTION
Implementation of `WormholeExecutorDataAdapter` which is a Wormhole adapter for data messages which uses on the on-chain Wormhole Executor.

Key implementation details:
* Updated to latest version of `wormhole-solidity-sdk`. To compile we had to enable `viaIR` and move a variable in `HubRewardsV2`.
* Changed finalised consistency level constant to follow [updated recommendation](https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/d80e0f6cd16f281f3f9df435e98e823b4212b2ad/src/constants/ConsistencyLevel.sol#L7).
* Must check that the target chain of the Wormhole message is directed to this chain. This is done by encoding the target chain into the message with `WormholeExecutorMetadata` and then comparing to the field `thisWormholeChainId`.
* Must check that the `msg.value` is sufficient. This is done by encoding the `message.params.receiverValue` into the message with `WormholeExecutorMetadata` and then comparing to the `msg.value`.
* Made `quoterAddress` updateable
* Added replay protection as this is no longer being done for us. This is done by using `VaaLib.calcVaaDoubleHashMem` and `HashReplayProtectionLib.replayProtect`

Migration plan is to add `WormholeExecutorDataAdapter` at new adapter id in `BridgeRouter`. Then remove existing `WormholeDataAdapter` and `WormholeCCTPAdapter`. The `WormholeExecutorDataAdapter` will act in place of the `WormholeDataAdapter` and the `CCIPTokenAdapter` will act in place of the `WormholeCCTPAdapter`.

References:
* https://github.com/wormhole-foundation/wormhole-solidity-sdk/releases/tag/v1.1.0
* https://github.com/wormhole-foundation/demo-hello-executor/blob/main/src/HelloWormholeOnChainQuote.sol